### PR TITLE
Dashes support in the schema organization name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.3.0 (2020-01-08)
+--------------------------
+- Add dashes support in the schema organization name.
+
 Version 0.2.0 (2019-10-30)
 --------------------------
 - Add ECMAScript Modules support.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-analytics-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Snowplow JavaScript and TypeScript Analytics SDK",
   "keywords": [
     "snowplow",

--- a/src/types.spec.ts
+++ b/src/types.spec.ts
@@ -96,6 +96,26 @@ describe('Contexts', () => {
 });
 
 describe('Unstruct', () => {
+  it('should support dashes in a schema organization name', () => {
+    expect(
+      Unstruct(
+        '',
+        JSON.stringify({
+          data: {
+            data: 'something',
+            schema: 'iglu:com.google.analytics.enhanced-ecommerce/productFieldObject/jsonschema/1-0-0',
+          },
+          schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
+        }),
+      ),
+    ).toEqual([
+      {
+        key: 'unstruct_event_com_google_analytics_enhanced_ecommerce_product_field_object_1',
+        value: 'something',
+      },
+    ]);
+  });
+
   it('should parse unstruct', () => {
     expect(
       Unstruct(

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
 
-const SCHEMA_PATTERN = /.+:([a-zA-Z0-9_.]+)\/([a-zA-Z0-9_-]+)\/[^/]+\/(.*)/;
+const SCHEMA_PATTERN = /.+:([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_-]+)\/[^/]+\/(.*)/;
 
 interface Context {
   schema: string;
@@ -41,7 +41,7 @@ function fixSchema(prefix: string, schema: string): string {
   }
 
   const [, organization, name, version] = match;
-  const snakeCaseOrganization = organization.replace(/\./g, '_').toLowerCase();
+  const snakeCaseOrganization = organization.replace(/[.-]/g, '_').toLowerCase();
   const snakeCaseName = name.replace(/([^A-Z_])([A-Z])/g, '$1_$2').toLowerCase();
   const [model] = version.split('-');
 


### PR DESCRIPTION
This pull-request adds dashes support in the schema organization name.

*Example:*
Schema like this `iglu:com.google.analytics.enhanced-ecommerce/productFieldObject/jsonschema/1-0-0` should be converted to key `unstruct_event_com_google_analytics_enhanced_ecommerce_product_field_object_1`.

Closes #12 .