### PR TITLE
Fix `refr_dvce_tstamp` field naming

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Version 0.3.0 (2020-01-08)
 --------------------------
 - Add dashes support in the schema organization name.
+- Rename `refr_device_tstamp` to `refr_dvce_tstamp`.
 
 Version 0.2.0 (2019-10-30)
 --------------------------

--- a/src/event.ts
+++ b/src/event.ts
@@ -137,7 +137,7 @@ export interface Event {
   etl_tags: string;
   dvce_sent_tstamp: number;
   refr_domain_userid: string;
-  refr_device_tstamp: number;
+  refr_dvce_tstamp: number;
   derived_contexts: unknown;
   domain_sessionid: string;
   derived_tstamp: number;

--- a/src/index.fixture.ts
+++ b/src/index.fixture.ts
@@ -210,7 +210,7 @@ export const event = {
   etl_tags: '',
   dvce_sent_tstamp: '',
   refr_domain_userid: '',
-  refr_device_tstamp: '',
+  refr_dvce_tstamp: '',
   derived_contexts: JSON.stringify(derivedContexts),
   domain_sessionid: '2b15e5c8-d3b1-11e4-b9d6-1681e6b88ec1',
   derived_tstamp: '2013-11-26 00:03:57.886',

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -137,7 +137,7 @@ export const EVENT_STRUCTURE = {
   etl_tags: String,
   dvce_sent_tstamp: Timestamp,
   refr_domain_userid: String,
-  refr_device_tstamp: Timestamp,
+  refr_dvce_tstamp: Timestamp,
   derived_contexts: Contexts,
   domain_sessionid: String,
   derived_tstamp: Timestamp,


### PR DESCRIPTION
This pull-request fixes `refr_dvce_tstamp` field naming according to the [canonical event model](https://github.com/snowplow/snowplow/wiki/canonical-event-model#221-web-specific-fields).

The package version is bumped to 1.0.1 because 1.0.0 was deprecated a while ago and cannot be reused (see #8).

Closes #8 #13 .